### PR TITLE
Avoid downloading files at startup

### DIFF
--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -20,6 +20,11 @@ ADD ./scripts/entermediadb-extensions-deploy.sh /usr/bin/entermediadb-extensions
 #ADD ./services/startsshd.sh /usr/bin/startsshd.sh
 COPY ./conf/ant.sh /etc/profile.d/ant.sh
 RUN wget https://archive.apache.org/dist/ant/binaries/apache-ant-1.9.14-bin.zip && unzip apache-ant-1.9.14-bin.zip && rm -f apache-ant-1.9.14-bin.zip && mv apache-ant-1.9.14 /opt/ant && ln -s /opt/ant/bin/ant /usr/bin/ant && chmod +x /etc/profile.d/ant.sh && source /etc/profile.d/ant.sh
+RUN mkdir -p /usr/share/entermediadb/resources
+RUN curl -X GET -o /usr/share/entermediadb/resources/libx264-normal.ffpreset https://raw.githubusercontent.com/entermedia-community/entermediadb-installers/master/linux/usr/share/entermediadb/conf/ffmpeg/libx264-normal.ffpreset?reload=true
+RUN curl -X GET -o /usr/share/entermediadb/resources/delegates.xml https://raw.githubusercontent.com/entermedia-community/entermediadb-installers/master/linux/tools/im/delegates.xml?reload=true
+RUN curl -X GET -o /usr/share/entermediadb/resources/policy.xml https://raw.githubusercontent.com/entermedia-community/entermediadb-installers/master/linux/tools/im/policy.xml?reload=true
+RUN curl -X GET -o /usr/share/entermediadb/resources/logrotate_config https://raw.githubusercontent.com/entermedia-community/entermediadb-docker/master/tomcat/conf/logrotate.conf?reload=true
 COPY ./conf/sysctl.conf /etc/sysctl.conf
 COPY ./conf/limits.conf /etc/security/limits.conf
 COPY ./insync.tar.gz /usr/bin/

--- a/tomcat/scripts/entermediadb-deploy.sh
+++ b/tomcat/scripts/entermediadb-deploy.sh
@@ -5,11 +5,21 @@
 EMCOMMON=/usr/share/entermediadb
 EMTARGET=/opt/entermediadb
 WEBAPP=$EMTARGET/webapp
+
 #Finish install
 if [[ ! `id -u` -eq 0 ]]; then
 	echo You must run this script as a superuser.
 	exit 1
 fi
+<<<<<<< e4e8993a3b81857bf59b012c9ff0112cb030e8c6
+=======
+
+##Rotate Logs
+if [[ ! -f /etc/logrotate.d/tomcat_$CLIENT_NAME ]]; then
+	cp $EMCOMMON/resources/logrotate_conf /etc/logrotate.d/tomcat_$CLIENT_NAME
+fi
+
+>>>>>>> Avoid downloading files at startup
 if [[ ! `id -u entermedia 2> /dev/null` ]]; then
 	groupadd -g $GROUPID entermedia
 	useradd -ms /bin/bash entermedia -g entermedia -u $USERID


### PR DESCRIPTION
Some configuration files were being downloaded at container's startup.  Now they are included in the docker container from the beginning.